### PR TITLE
Add missing #undef HAVE_APACHE_CONN_CLIENT_IP to config.h.in.

### DIFF
--- a/common/config.h.in
+++ b/common/config.h.in
@@ -23,6 +23,7 @@
 #undef APACHE2
 #undef HAVE_MOD_AUTHZ_HOST
 #undef HAVE_AP_REGEX_H
+#under HAVE_APACHE_CONN_CLIENT_IP
 
 /* lighttpd */
 #undef LIGHTTPD


### PR DESCRIPTION
Fix compiling for Apache 2.4.x.
